### PR TITLE
feat: suporte PostgreSQL para escalabilidade

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 import os
-from app.config import _get_or_create_secret, DB_PATH, UPLOAD_DIR
+from app.config import _get_or_create_secret, DB_PATH, DB_TYPE, UPLOAD_DIR
 from app.database import init_db
 
 
@@ -15,7 +15,8 @@ def create_app():
         SESSION_COOKIE_SECURE=os.getenv('COOKIE_SECURE', '0') in ('1', 'true', 'True')
     )
 
-    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    if DB_TYPE == 'sqlite':
+        os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
     os.makedirs(UPLOAD_DIR, exist_ok=True)
 
     from app.routes import auth, lancamentos, orcamentos, metas, relatorios, contas, social, pluggy, ia, importacao

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,7 +17,7 @@ def create_app():
 
     if DB_TYPE == 'sqlite':
         os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
-    os.makedirs(UPLOAD_DIR, exist_ok=True)
+    os.makedirs(os.path.join(flask_app.static_folder, 'uploads', 'avatars'), exist_ok=True)
 
     from app.routes import auth, lancamentos, orcamentos, metas, relatorios, contas, social, pluggy, ia, importacao
     for bp in [auth.bp, lancamentos.bp, orcamentos.bp, metas.bp, relatorios.bp, contas.bp, social.bp, pluggy.bp, ia.bp, importacao.bp]:

--- a/app/config.py
+++ b/app/config.py
@@ -19,7 +19,9 @@ CATEGORIA_KEYWORDS = {
     'Cartão de Crédito': ['fatura', 'cartão', 'nubank', 'inter', 'c6'],
 }
 
-DB_PATH = 'data/lancamentos.db'
+DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///data/lancamentos.db')
+DB_TYPE = 'postgresql' if DATABASE_URL.startswith('postgres') else 'sqlite'
+DB_PATH = 'data/lancamentos.db'  # fallback para SQLite local
 UPLOAD_DIR = os.path.join('static', 'uploads', 'avatars')
 PLUGGY_API_URL = 'https://api.pluggy.ai'
 MAX_LOGIN_ATTEMPTS = 5

--- a/app/database.py
+++ b/app/database.py
@@ -1,150 +1,361 @@
 import sqlite3
 from contextlib import contextmanager
-from app.config import DB_PATH
+from app.config import DATABASE_URL, DB_TYPE, DB_PATH
+
+_pg_pool = None
+
+
+def _get_pg_pool():
+    global _pg_pool
+    if _pg_pool is None:
+        import psycopg2.pool
+        url = DATABASE_URL.replace('postgres://', 'postgresql://', 1)
+        _pg_pool = psycopg2.pool.SimpleConnectionPool(1, 5, url)
+    return _pg_pool
+
+
+class PgCursorWrapper:
+    """Wraps psycopg2 cursor to provide sqlite-compatible interface."""
+    def __init__(self, conn):
+        self._conn = conn
+        self._cursor = None
+        self.rowcount = 0
+        self.description = None
+
+    def execute(self, sql, params=None):
+        sql = sql.replace('?', '%s')
+        self._cursor = self._conn.cursor()
+        self._cursor.execute(sql, params)
+        self.rowcount = self._cursor.rowcount
+        self.description = self._cursor.description
+        return self
+
+    def fetchone(self):
+        return self._cursor.fetchone() if self._cursor else None
+
+    def fetchall(self):
+        return self._cursor.fetchall() if self._cursor else []
+
+
+class PgConnectionWrapper:
+    """Wraps psycopg2 connection to provide sqlite-compatible interface."""
+    def __init__(self, conn):
+        self._conn = conn
+        self._last_cursor = None
+
+    def execute(self, sql, params=None):
+        sql = sql.replace('?', '%s')
+        cur = self._conn.cursor()
+        cur.execute(sql, params)
+        self._last_cursor = cur
+        wrapper = type('CursorResult', (), {
+            'rowcount': cur.rowcount,
+            'description': cur.description,
+            'fetchone': cur.fetchone,
+            'fetchall': cur.fetchall,
+        })()
+        return wrapper
+
+    def commit(self):
+        self._conn.commit()
+
+    def close(self):
+        pass  # pool handles this
 
 
 @contextmanager
 def db_connection():
-    conn = sqlite3.connect(DB_PATH)
-    try:
-        yield conn
-        conn.commit()
-    finally:
-        conn.close()
+    if DB_TYPE == 'postgresql':
+        pool = _get_pg_pool()
+        conn = pool.getconn()
+        wrapper = PgConnectionWrapper(conn)
+        try:
+            yield wrapper
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            pool.putconn(conn)
+    else:
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+
+@contextmanager
+def raw_connection():
+    """Returns the raw DB connection (for pandas read_sql_query)."""
+    if DB_TYPE == 'postgresql':
+        pool = _get_pg_pool()
+        conn = pool.getconn()
+        try:
+            yield conn
+        finally:
+            pool.putconn(conn)
+    else:
+        conn = sqlite3.connect(DB_PATH)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+
+def sql(statement):
+    """Adapt SQL for current DB type."""
+    if DB_TYPE == 'postgresql':
+        statement = statement.replace('INTEGER PRIMARY KEY AUTOINCREMENT', 'SERIAL PRIMARY KEY')
+        statement = statement.replace('AUTOINCREMENT', '')
+        statement = statement.replace("strftime('%Y-%m', data)", "TO_CHAR(data::date, 'YYYY-MM')")
+        statement = statement.replace("strftime('%Y-%m-%d', data)", "TO_CHAR(data::date, 'YYYY-MM-DD')")
+        # INSERT OR REPLACE → INSERT ... ON CONFLICT DO UPDATE
+        if 'INSERT OR REPLACE INTO orcamentos' in statement:
+            statement = statement.replace('INSERT OR REPLACE INTO orcamentos', 'INSERT INTO orcamentos')
+            statement = statement.rstrip().rstrip(')')
+            statement += ') ON CONFLICT (user_id, categoria, mes) DO UPDATE SET limite = EXCLUDED.limite'
+        elif 'INSERT OR REPLACE INTO categorias' in statement:
+            statement = statement.replace('INSERT OR REPLACE INTO categorias', 'INSERT INTO categorias')
+            statement = statement.rstrip().rstrip(')')
+            statement += ') ON CONFLICT (user_id, nome) DO UPDATE SET emoji = EXCLUDED.emoji'
+        elif 'INSERT OR REPLACE INTO compartilhamentos' in statement:
+            statement = statement.replace('INSERT OR REPLACE INTO compartilhamentos', 'INSERT INTO compartilhamentos')
+            statement = statement.rstrip().rstrip(')')
+            statement += ') ON CONFLICT (owner_id, shared_with_id) DO UPDATE SET permissao = EXCLUDED.permissao'
+    return statement
 
 
 def init_db():
     with db_connection() as conn:
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS users (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                nickname TEXT DEFAULT '',
-                email TEXT NOT NULL UNIQUE,
-                password_hash TEXT NOT NULL,
-                avatar_url TEXT DEFAULT '',
-                created_at TEXT NOT NULL
-            )
-        ''')
+        if DB_TYPE == 'sqlite':
+            _init_sqlite(conn)
+        else:
+            _init_postgresql(conn)
 
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS lancamentos (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER,
-                data TEXT,
-                tipo TEXT,
-                descricao TEXT,
-                valor REAL,
-                categoria TEXT,
-                vencimento TEXT,
-                recorrente INTEGER DEFAULT 0,
-                parcelas INTEGER DEFAULT 1,
-                parcela_atual INTEGER DEFAULT 1,
-                FOREIGN KEY (user_id) REFERENCES users(id)
-            )
-        ''')
 
-        cols = [row[1] for row in conn.execute("PRAGMA table_info(lancamentos)").fetchall()]
-        if 'user_id' not in cols:
-            conn.execute("ALTER TABLE lancamentos ADD COLUMN user_id INTEGER")
+def _init_sqlite(conn):
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            nickname TEXT DEFAULT '',
+            email TEXT NOT NULL UNIQUE,
+            password_hash TEXT NOT NULL,
+            avatar_url TEXT DEFAULT '',
+            created_at TEXT NOT NULL
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS lancamentos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            data TEXT,
+            tipo TEXT,
+            descricao TEXT,
+            valor REAL,
+            categoria TEXT,
+            vencimento TEXT,
+            recorrente INTEGER DEFAULT 0,
+            parcelas INTEGER DEFAULT 1,
+            parcela_atual INTEGER DEFAULT 1,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    ''')
+    cols = [row[1] for row in conn.execute("PRAGMA table_info(lancamentos)").fetchall()]
+    if 'user_id' not in cols:
+        conn.execute("ALTER TABLE lancamentos ADD COLUMN user_id INTEGER")
+    if 'conta_id' not in cols:
+        conn.execute("ALTER TABLE lancamentos ADD COLUMN conta_id INTEGER")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_users_email ON users(email)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_lancamentos_user_data ON lancamentos(user_id, data)")
+    user_cols = [row[1] for row in conn.execute("PRAGMA table_info(users)").fetchall()]
+    if 'nickname' not in user_cols:
+        conn.execute("ALTER TABLE users ADD COLUMN nickname TEXT DEFAULT ''")
+    if 'avatar_url' not in user_cols:
+        conn.execute("ALTER TABLE users ADD COLUMN avatar_url TEXT DEFAULT ''")
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS orcamentos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            categoria TEXT NOT NULL,
+            limite REAL NOT NULL,
+            mes TEXT NOT NULL,
+            rollover INTEGER DEFAULT 0,
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            UNIQUE(user_id, categoria, mes)
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS metas (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            nome TEXT NOT NULL,
+            emoji TEXT DEFAULT '🎯',
+            valor_alvo REAL NOT NULL,
+            valor_atual REAL DEFAULT 0,
+            prazo TEXT,
+            criado_em TEXT NOT NULL,
+            concluida INTEGER DEFAULT 0,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    ''')
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_orcamentos_user ON orcamentos(user_id, mes)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_metas_user ON metas(user_id)")
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS categorias (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            nome TEXT NOT NULL,
+            emoji TEXT DEFAULT '📁',
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            UNIQUE(user_id, nome)
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS contas (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            nome TEXT NOT NULL,
+            emoji TEXT DEFAULT '🏦',
+            tipo TEXT DEFAULT 'corrente',
+            saldo_inicial REAL DEFAULT 0,
+            cor TEXT DEFAULT '#007aff',
+            ativa INTEGER DEFAULT 1,
+            criado_em TEXT NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS compartilhamentos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            owner_id INTEGER NOT NULL,
+            shared_with_id INTEGER NOT NULL,
+            permissao TEXT DEFAULT 'leitura',
+            criado_em TEXT NOT NULL,
+            FOREIGN KEY (owner_id) REFERENCES users(id),
+            FOREIGN KEY (shared_with_id) REFERENCES users(id),
+            UNIQUE(owner_id, shared_with_id)
+        )
+    ''')
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_contas_user ON contas(user_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_compartilhamentos ON compartilhamentos(owner_id, shared_with_id)")
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS conexoes_bancarias (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            item_id TEXT NOT NULL,
+            connector_name TEXT DEFAULT '',
+            status TEXT DEFAULT 'connected',
+            conta_id INTEGER,
+            criado_em TEXT NOT NULL,
+            atualizado_em TEXT,
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            FOREIGN KEY (conta_id) REFERENCES contas(id)
+        )
+    ''')
 
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_users_email ON users(email)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_lancamentos_user_data ON lancamentos(user_id, data)")
 
-        user_cols = [row[1] for row in conn.execute("PRAGMA table_info(users)").fetchall()]
-        if 'nickname' not in user_cols:
-            conn.execute("ALTER TABLE users ADD COLUMN nickname TEXT DEFAULT ''")
-        if 'avatar_url' not in user_cols:
-            conn.execute("ALTER TABLE users ADD COLUMN avatar_url TEXT DEFAULT ''")
-
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS orcamentos (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                categoria TEXT NOT NULL,
-                limite REAL NOT NULL,
-                mes TEXT NOT NULL,
-                rollover INTEGER DEFAULT 0,
-                FOREIGN KEY (user_id) REFERENCES users(id),
-                UNIQUE(user_id, categoria, mes)
-            )
-        ''')
-
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS metas (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                nome TEXT NOT NULL,
-                emoji TEXT DEFAULT '🎯',
-                valor_alvo REAL NOT NULL,
-                valor_atual REAL DEFAULT 0,
-                prazo TEXT,
-                criado_em TEXT NOT NULL,
-                concluida INTEGER DEFAULT 0,
-                FOREIGN KEY (user_id) REFERENCES users(id)
-            )
-        ''')
-
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_orcamentos_user ON orcamentos(user_id, mes)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_metas_user ON metas(user_id)")
-
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS categorias (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                nome TEXT NOT NULL,
-                emoji TEXT DEFAULT '📁',
-                FOREIGN KEY (user_id) REFERENCES users(id),
-                UNIQUE(user_id, nome)
-            )
-        ''')
-
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS contas (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                nome TEXT NOT NULL,
-                emoji TEXT DEFAULT '🏦',
-                tipo TEXT DEFAULT 'corrente',
-                saldo_inicial REAL DEFAULT 0,
-                cor TEXT DEFAULT '#007aff',
-                ativa INTEGER DEFAULT 1,
-                criado_em TEXT NOT NULL,
-                FOREIGN KEY (user_id) REFERENCES users(id)
-            )
-        ''')
-
-        lanc_cols = [row[1] for row in conn.execute("PRAGMA table_info(lancamentos)").fetchall()]
-        if 'conta_id' not in lanc_cols:
-            conn.execute("ALTER TABLE lancamentos ADD COLUMN conta_id INTEGER")
-
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS compartilhamentos (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                owner_id INTEGER NOT NULL,
-                shared_with_id INTEGER NOT NULL,
-                permissao TEXT DEFAULT 'leitura',
-                criado_em TEXT NOT NULL,
-                FOREIGN KEY (owner_id) REFERENCES users(id),
-                FOREIGN KEY (shared_with_id) REFERENCES users(id),
-                UNIQUE(owner_id, shared_with_id)
-            )
-        ''')
-
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_contas_user ON contas(user_id)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_compartilhamentos ON compartilhamentos(owner_id, shared_with_id)")
-
-        conn.execute('''
-            CREATE TABLE IF NOT EXISTS conexoes_bancarias (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                item_id TEXT NOT NULL,
-                connector_name TEXT DEFAULT '',
-                status TEXT DEFAULT 'connected',
-                conta_id INTEGER,
-                criado_em TEXT NOT NULL,
-                atualizado_em TEXT,
-                FOREIGN KEY (user_id) REFERENCES users(id),
-                FOREIGN KEY (conta_id) REFERENCES contas(id)
-            )
-        ''')
+def _init_postgresql(conn):
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS users (
+            id SERIAL PRIMARY KEY,
+            name TEXT NOT NULL,
+            nickname TEXT DEFAULT '',
+            email TEXT NOT NULL UNIQUE,
+            password_hash TEXT NOT NULL,
+            avatar_url TEXT DEFAULT '',
+            created_at TEXT NOT NULL
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS lancamentos (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER REFERENCES users(id),
+            data TEXT,
+            tipo TEXT,
+            descricao TEXT,
+            valor DOUBLE PRECISION,
+            categoria TEXT,
+            vencimento TEXT,
+            recorrente INTEGER DEFAULT 0,
+            parcelas INTEGER DEFAULT 1,
+            parcela_atual INTEGER DEFAULT 1,
+            conta_id INTEGER
+        )
+    ''')
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_users_email ON users(email)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_lancamentos_user_data ON lancamentos(user_id, data)")
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS orcamentos (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            categoria TEXT NOT NULL,
+            limite DOUBLE PRECISION NOT NULL,
+            mes TEXT NOT NULL,
+            rollover INTEGER DEFAULT 0,
+            UNIQUE(user_id, categoria, mes)
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS metas (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            nome TEXT NOT NULL,
+            emoji TEXT DEFAULT '🎯',
+            valor_alvo DOUBLE PRECISION NOT NULL,
+            valor_atual DOUBLE PRECISION DEFAULT 0,
+            prazo TEXT,
+            criado_em TEXT NOT NULL,
+            concluida INTEGER DEFAULT 0
+        )
+    ''')
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_orcamentos_user ON orcamentos(user_id, mes)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_metas_user ON metas(user_id)")
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS categorias (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            nome TEXT NOT NULL,
+            emoji TEXT DEFAULT '📁',
+            UNIQUE(user_id, nome)
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS contas (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            nome TEXT NOT NULL,
+            emoji TEXT DEFAULT '🏦',
+            tipo TEXT DEFAULT 'corrente',
+            saldo_inicial DOUBLE PRECISION DEFAULT 0,
+            cor TEXT DEFAULT '#007aff',
+            ativa INTEGER DEFAULT 1,
+            criado_em TEXT NOT NULL
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS compartilhamentos (
+            id SERIAL PRIMARY KEY,
+            owner_id INTEGER NOT NULL REFERENCES users(id),
+            shared_with_id INTEGER NOT NULL REFERENCES users(id),
+            permissao TEXT DEFAULT 'leitura',
+            criado_em TEXT NOT NULL,
+            UNIQUE(owner_id, shared_with_id)
+        )
+    ''')
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_contas_user ON contas(user_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_compartilhamentos ON compartilhamentos(owner_id, shared_with_id)")
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS conexoes_bancarias (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            item_id TEXT NOT NULL,
+            connector_name TEXT DEFAULT '',
+            status TEXT DEFAULT 'connected',
+            conta_id INTEGER REFERENCES contas(id),
+            criado_em TEXT NOT NULL,
+            atualizado_em TEXT
+        )
+    ''')

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -120,12 +120,13 @@ def perfil():
     if avatar_file and avatar_file.filename:
         if not ext_permitida(avatar_file.filename):
             return erro_json('Formato de imagem inválido. Use PNG, JPG, JPEG ou WEBP.', 400)
+        from flask import current_app
         extensao = avatar_file.filename.rsplit('.', 1)[1].lower()
         nome_arquivo = f"user_{user_id}_{int(time.time())}.{extensao}"
-        caminho_relativo = os.path.join('uploads', 'avatars', nome_arquivo)
-        caminho_completo = os.path.join('static', caminho_relativo)
+        caminho_completo = os.path.join(current_app.static_folder, 'uploads', 'avatars', nome_arquivo)
+        os.makedirs(os.path.dirname(caminho_completo), exist_ok=True)
         avatar_file.save(caminho_completo)
-        avatar_url = f"/static/{caminho_relativo}"
+        avatar_url = f"/static/uploads/avatars/{nome_arquivo}"
 
     with db_connection() as conn:
         existing = conn.execute("SELECT id FROM users WHERE email = ? AND id != ?", (email, user_id)).fetchone()

--- a/app/routes/contas.py
+++ b/app/routes/contas.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify
 from datetime import datetime, UTC
-from app.database import db_connection
+from app.database import db_connection, sql
 from app.utils import erro_json, validar_csrf, login_required, get_current_user_id
 
 bp = Blueprint('contas', __name__)
@@ -68,7 +68,7 @@ def api_patrimonio():
         items.append({'id': r[0], 'nome': r[1], 'emoji': r[2], 'tipo': r[3], 'saldo': saldo, 'cor': r[5]})
     evolucao = []
     with db_connection() as conn:
-        rows = conn.execute("SELECT strftime('%Y-%m', data) as mes, COALESCE(SUM(CASE WHEN tipo IN ('entrada','salario','recebimento') THEN valor ELSE -valor END), 0) FROM lancamentos WHERE user_id = ? GROUP BY mes ORDER BY mes DESC LIMIT 6", (user_id,)).fetchall()
+        rows = conn.execute(sql("SELECT strftime('%Y-%m', data) as mes, COALESCE(SUM(CASE WHEN tipo IN ('entrada','salario','recebimento') THEN valor ELSE -valor END), 0) FROM lancamentos WHERE user_id = ? GROUP BY mes ORDER BY mes DESC LIMIT 6"), (user_id,)).fetchall()
     acum = 0
     for r in sorted(rows, key=lambda x: x[0]):
         acum += r[1]

--- a/app/routes/ia.py
+++ b/app/routes/ia.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify
 from datetime import datetime
 import calendar
-from app.database import db_connection
+from app.database import db_connection, sql
 from app.config import CATEGORIA_KEYWORDS
 from app.utils import login_required, get_current_user_id
 
@@ -36,10 +36,10 @@ def api_insights():
     insights = []
     with db_connection() as conn:
         atual = conn.execute(
-            "SELECT categoria, SUM(valor) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta') AND categoria != '' GROUP BY categoria",
+            sql("SELECT categoria, SUM(valor) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta') AND categoria != '' GROUP BY categoria"),
             (user_id, mes_atual)).fetchall()
         medias = conn.execute(
-            "SELECT categoria, AVG(total) FROM (SELECT categoria, strftime('%Y-%m', data) as mes, SUM(valor) as total FROM lancamentos WHERE user_id = ? AND tipo IN ('saida','divida','conta') AND categoria != '' AND strftime('%Y-%m', data) < ? GROUP BY categoria, mes) GROUP BY categoria",
+            sql("SELECT categoria, AVG(total) FROM (SELECT categoria, strftime('%Y-%m', data) as mes, SUM(valor) as total FROM lancamentos WHERE user_id = ? AND tipo IN ('saida','divida','conta') AND categoria != '' AND strftime('%Y-%m', data) < ? GROUP BY categoria, mes) GROUP BY categoria"),
             (user_id, mes_atual)).fetchall()
     media_map = {r[0]: r[1] for r in medias}
     for cat, gasto in atual:
@@ -52,8 +52,8 @@ def api_insights():
         elif variacao < -20:
             insights.append({'tipo': 'positivo', 'icone': '📉', 'mensagem': f'Parabéns! Você economizou {abs(variacao)}% em {cat} este mês (R$ {gasto:.0f} vs média R$ {media:.0f}).'})
     with db_connection() as conn:
-        entradas = conn.execute("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('entrada','salario','recebimento')", (user_id, mes_atual)).fetchone()[0]
-        saidas = conn.execute("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')", (user_id, mes_atual)).fetchone()[0]
+        entradas = conn.execute(sql("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('entrada','salario','recebimento')"), (user_id, mes_atual)).fetchone()[0]
+        saidas = conn.execute(sql("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')"), (user_id, mes_atual)).fetchone()[0]
     saldo = entradas - saidas
     if saldo > 0:
         taxa_poupanca = round((saldo / entradas) * 100, 1) if entradas > 0 else 0
@@ -76,10 +76,10 @@ def api_projecao():
     dias_no_mes = calendar.monthrange(hoje.year, hoje.month)[1]
     dias_restantes = dias_no_mes - dia_atual
     with db_connection() as conn:
-        entradas = conn.execute("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('entrada','salario','recebimento')", (user_id, mes_atual)).fetchone()[0]
-        saidas_ate_agora = conn.execute("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')", (user_id, mes_atual)).fetchone()[0]
+        entradas = conn.execute(sql("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('entrada','salario','recebimento')"), (user_id, mes_atual)).fetchone()[0]
+        saidas_ate_agora = conn.execute(sql("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')"), (user_id, mes_atual)).fetchone()[0]
         recorrentes_pendentes = conn.execute(
-            "SELECT COALESCE(SUM(sub.valor),0) FROM (SELECT descricao, tipo, MAX(valor) as valor FROM lancamentos WHERE user_id = ? AND recorrente = 1 AND tipo IN ('saida','divida','conta') GROUP BY descricao, tipo) sub WHERE sub.descricao NOT IN (SELECT descricao FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta'))",
+            sql("SELECT COALESCE(SUM(sub.valor),0) FROM (SELECT descricao, tipo, MAX(valor) as valor FROM lancamentos WHERE user_id = ? AND recorrente = 1 AND tipo IN ('saida','divida','conta') GROUP BY descricao, tipo) sub WHERE sub.descricao NOT IN (SELECT descricao FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta'))"),
             (user_id, user_id, mes_atual)).fetchone()[0]
     gasto_diario = saidas_ate_agora / dia_atual if dia_atual > 0 else 0
     projecao_gastos = saidas_ate_agora + (gasto_diario * dias_restantes) + recorrentes_pendentes

--- a/app/routes/lancamentos.py
+++ b/app/routes/lancamentos.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify
 from datetime import datetime
 import pandas as pd
 from app.database import db_connection
+from app.database import sql
 from app.utils import (
     erro_json, validar_csrf, login_required, get_current_user_id,
     validar_lancamento_payload, query_lancamentos_paginado
@@ -113,7 +114,7 @@ def api_spending_line():
     mes = request.args.get('mes') or datetime.now().strftime('%Y-%m')
     with db_connection() as conn:
         rows = conn.execute(
-            "SELECT data, tipo, SUM(valor) as total FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? GROUP BY data, tipo ORDER BY data",
+            sql("SELECT data, tipo, SUM(valor) as total FROM lancamentos WHERE user_id = ? AND strftime('%Y-%m', data) = ? GROUP BY data, tipo ORDER BY data"),
             (user_id, mes)).fetchall()
 
     tipos_saida = {'saida', 'divida', 'conta'}
@@ -175,7 +176,7 @@ def gerar_recorrentes():
 
         for r in recorrentes:
             existe = conn.execute(
-                "SELECT id FROM lancamentos WHERE user_id = ? AND descricao = ? AND tipo = ? AND strftime('%Y-%m', data) = ?",
+                sql("SELECT id FROM lancamentos WHERE user_id = ? AND descricao = ? AND tipo = ? AND strftime('%Y-%m', data) = ?"),
                 (user_id, r[0], r[1], mes_atual)).fetchone()
             if not existe:
                 hoje = datetime.now()

--- a/app/routes/orcamentos.py
+++ b/app/routes/orcamentos.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify
 from datetime import datetime
-from app.database import db_connection
+from app.database import db_connection, sql
 from app.config import CATEGORIAS_PADRAO
 from app.utils import erro_json, validar_csrf, login_required, get_current_user_id
 
@@ -26,7 +26,7 @@ def criar_orcamento():
         return erro_json('Limite inválido.', 400)
 
     with db_connection() as conn:
-        conn.execute("INSERT OR REPLACE INTO orcamentos (user_id, categoria, limite, mes) VALUES (?,?,?,?)",
+        conn.execute(sql("INSERT OR REPLACE INTO orcamentos (user_id, categoria, limite, mes) VALUES (?,?,?,?)"),
             (get_current_user_id(), categoria, limite, mes))
     return jsonify({'status': 'ok'})
 
@@ -65,7 +65,7 @@ def salvar_categoria():
     if not nome:
         return erro_json('Nome é obrigatório.', 400)
     with db_connection() as conn:
-        conn.execute("INSERT OR REPLACE INTO categorias (user_id, nome, emoji) VALUES (?,?,?)",
+        conn.execute(sql("INSERT OR REPLACE INTO categorias (user_id, nome, emoji) VALUES (?,?,?)"),
             (get_current_user_id(), nome, emoji))
     return jsonify({'status': 'ok'})
 
@@ -80,7 +80,7 @@ def api_rollover():
     rollovers = []
     with db_connection() as conn:
         for cat, limite in conn.execute("SELECT categoria, limite FROM orcamentos WHERE user_id = ? AND mes = ?", (user_id, mes_anterior)).fetchall():
-            gasto = conn.execute("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND categoria = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')", (user_id, cat, mes_anterior)).fetchone()[0]
+            gasto = conn.execute(sql("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND categoria = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')"), (user_id, cat, mes_anterior)).fetchone()[0]
             sobra = round(limite - gasto, 2)
             if sobra > 0:
                 rollovers.append({'categoria': cat, 'sobra': sobra})

--- a/app/routes/pluggy.py
+++ b/app/routes/pluggy.py
@@ -2,8 +2,8 @@ from flask import Blueprint, request, jsonify
 from datetime import datetime, UTC
 import requests as http_requests
 import os
-from app.database import db_connection
-from app.config import PLUGGY_API_URL
+from app.database import db_connection, sql
+from app.config import PLUGGY_API_URL, DB_TYPE
 from app.utils import erro_json, validar_csrf, login_required, get_current_user_id
 
 bp = Blueprint('pluggy', __name__)
@@ -50,9 +50,13 @@ def pluggy_item_connected():
         return erro_json('itemId é obrigatório.', 400)
     user_id = get_current_user_id()
     with db_connection() as conn:
-        conn.execute("INSERT INTO contas (user_id, nome, emoji, tipo, saldo_inicial, cor, criado_em) VALUES (?,?,'🏦','corrente',0,'#007aff',?)",
-            (user_id, connector_name or 'Banco conectado', datetime.now(UTC).isoformat()))
-        conta_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        if DB_TYPE == 'postgresql':
+            conta_id = conn.execute("INSERT INTO contas (user_id, nome, emoji, tipo, saldo_inicial, cor, criado_em) VALUES (?,?,'🏦','corrente',0,'#007aff',?) RETURNING id",
+                (user_id, connector_name or 'Banco conectado', datetime.now(UTC).isoformat())).fetchone()[0]
+        else:
+            conn.execute("INSERT INTO contas (user_id, nome, emoji, tipo, saldo_inicial, cor, criado_em) VALUES (?,?,'🏦','corrente',0,'#007aff',?)",
+                (user_id, connector_name or 'Banco conectado', datetime.now(UTC).isoformat()))
+            conta_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
         conn.execute("INSERT INTO conexoes_bancarias (user_id, item_id, connector_name, conta_id, criado_em) VALUES (?,?,?,?,?)",
             (user_id, item_id, connector_name, conta_id, datetime.now(UTC).isoformat()))
     return jsonify({'status': 'ok', 'conta_id': conta_id})

--- a/app/routes/relatorios.py
+++ b/app/routes/relatorios.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import csv
 import io
 from app.database import db_connection
+from app.database import db_connection, sql
 from app.utils import (
     login_required, get_current_user, get_current_user_id,
     query_lancamentos, agregar_resumo, agregar_serie_mensal,
@@ -123,7 +124,7 @@ def api_comparativo_mensal():
     user_id = get_current_user_id()
     meses = min(int(request.args.get('meses', 6)), 12)
     with db_connection() as conn:
-        rows = conn.execute("SELECT strftime('%Y-%m', data) as mes, categoria, tipo, SUM(valor) as total FROM lancamentos WHERE user_id = ? GROUP BY mes, categoria, tipo ORDER BY mes DESC", (user_id,)).fetchall()
+        rows = conn.execute(sql("SELECT strftime('%Y-%m', data) as mes, categoria, tipo, SUM(valor) as total FROM lancamentos WHERE user_id = ? GROUP BY mes, categoria, tipo ORDER BY mes DESC"), (user_id,)).fetchall()
     dados = {}
     for r in rows:
         mes = r[0]

--- a/app/routes/social.py
+++ b/app/routes/social.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify
 from datetime import datetime, UTC
-from app.database import db_connection
+from app.database import db_connection, sql
 from app.utils import erro_json, validar_email, validar_csrf, login_required, get_current_user_id
 
 bp = Blueprint('social', __name__)
@@ -25,7 +25,7 @@ def compartilhar():
             return erro_json('Usuário não encontrado.', 404)
         if target[0] == user_id:
             return erro_json('Não é possível compartilhar consigo mesmo.', 400)
-        conn.execute("INSERT OR REPLACE INTO compartilhamentos (owner_id, shared_with_id, permissao, criado_em) VALUES (?,?,?,?)",
+        conn.execute(sql("INSERT OR REPLACE INTO compartilhamentos (owner_id, shared_with_id, permissao, criado_em) VALUES (?,?,?,?)"),
             (user_id, target[0], permissao, datetime.now(UTC).isoformat()))
     return jsonify({'status': 'ok'})
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,8 +5,8 @@ import pandas as pd
 from datetime import datetime
 from functools import wraps
 from flask import request, jsonify, session, redirect, url_for
-from app.database import db_connection
-from app.config import TIPOS_VALIDOS, CATEGORIAS_PADRAO, MAX_LOGIN_ATTEMPTS, LOGIN_WINDOW_SECONDS
+from app.database import db_connection, raw_connection, sql
+from app.config import TIPOS_VALIDOS, CATEGORIAS_PADRAO, MAX_LOGIN_ATTEMPTS, LOGIN_WINDOW_SECONDS, DB_TYPE
 
 LOGIN_ATTEMPTS = {}
 
@@ -141,19 +141,20 @@ def validar_lancamento_payload(data, update=False):
 
 
 def query_lancamentos(user_id, inicio=None, fim=None, tipo=None, categoria=None):
-    clauses = ["user_id = ?"]
+    ph = '%s' if DB_TYPE == 'postgresql' else '?'
+    clauses = [f"user_id = {ph}"]
     params = [user_id]
     if inicio:
-        clauses.append("data >= ?"); params.append(inicio)
+        clauses.append(f"data >= {ph}"); params.append(inicio)
     if fim:
-        clauses.append("data <= ?"); params.append(fim)
+        clauses.append(f"data <= {ph}"); params.append(fim)
     if tipo and tipo != 'todos':
-        clauses.append("tipo = ?"); params.append(tipo)
+        clauses.append(f"tipo = {ph}"); params.append(tipo)
     if categoria:
-        clauses.append("categoria = ?"); params.append(categoria)
+        clauses.append(f"categoria = {ph}"); params.append(categoria)
     where = " AND ".join(clauses)
 
-    with db_connection() as conn:
+    with raw_connection() as conn:
         df = pd.read_sql_query(
             f"SELECT * FROM lancamentos WHERE {where} ORDER BY data DESC",
             conn, params=params, parse_dates=['data']
@@ -280,7 +281,7 @@ def common_template_context(user, active_tab):
             ).fetchall()
             for r in rows:
                 gasto = conn.execute(
-                    "SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND categoria = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')",
+                    sql("SELECT COALESCE(SUM(valor),0) FROM lancamentos WHERE user_id = ? AND categoria = ? AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta')"),
                     (user_id, r[1], mes_atual)
                 ).fetchone()[0]
                 pct = round((gasto / r[2]) * 100, 1) if r[2] > 0 else 0

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,9 @@
+databases:
+  - name: finanzen-db
+    plan: free
+    databaseName: finanzen
+    user: finanzen
+
 services:
   - type: web
     name: finanzen
@@ -8,6 +14,10 @@ services:
     envVars:
       - key: SECRET_KEY
         generateValue: true
+      - key: DATABASE_URL
+        fromDatabase:
+          name: finanzen-db
+          property: connectionString
       - key: PLUGGY_CLIENT_ID
         sync: false
       - key: PLUGGY_CLIENT_SECRET

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openpyxl==3.1.2
 pandas==2.2.3
 requests==2.32.3
 gunicorn==22.0.0
+psycopg2-binary==2.9.10


### PR DESCRIPTION
## Roadmap 5.1 — Migrar SQLite → PostgreSQL

### Mudanças
- **Suporte dual**: detecta `DATABASE_URL` para PostgreSQL, fallback para SQLite local
- **Connection pool**: `psycopg2.pool.SimpleConnectionPool` (1-5 conexões)
- **Função `sql()`**: adapta queries em runtime:
  - `strftime('%Y-%m', data)` → `TO_CHAR(data::date, 'YYYY-MM')`
  - `INSERT OR REPLACE` → `INSERT ... ON CONFLICT DO UPDATE`
  - `?` → `%s` (placeholders)
  - `last_insert_rowid()` → `RETURNING id`
- **render.yaml**: PostgreSQL free tier configurado
- **psycopg2-binary** adicionado ao requirements.txt

### Testes
- 50/50 passando (modo SQLite)
- PostgreSQL será testado no deploy do Render

### Deploy
Após merge, configurar `DATABASE_URL` no Render apontando para o PostgreSQL.