### PR TITLE
feat: notificações push PWA

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,8 +19,8 @@ def create_app():
         os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
     os.makedirs(os.path.join(flask_app.static_folder, 'uploads', 'avatars'), exist_ok=True)
 
-    from app.routes import auth, lancamentos, orcamentos, metas, relatorios, contas, social, pluggy, ia, importacao, onboarding
-    for bp in [auth.bp, lancamentos.bp, orcamentos.bp, metas.bp, relatorios.bp, contas.bp, social.bp, pluggy.bp, ia.bp, importacao.bp, onboarding.bp]:
+    from app.routes import auth, lancamentos, orcamentos, metas, relatorios, contas, social, pluggy, ia, importacao, onboarding, push
+    for bp in [auth.bp, lancamentos.bp, orcamentos.bp, metas.bp, relatorios.bp, contas.bp, social.bp, pluggy.bp, ia.bp, importacao.bp, onboarding.bp, push.bp]:
         flask_app.register_blueprint(bp)
 
     init_db()

--- a/app/database.py
+++ b/app/database.py
@@ -252,6 +252,15 @@ def _init_sqlite(conn):
             FOREIGN KEY (conta_id) REFERENCES contas(id)
         )
     ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS push_subscriptions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            endpoint TEXT NOT NULL,
+            subscription_json TEXT NOT NULL,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    ''')
 
 
 def _init_postgresql(conn):
@@ -356,5 +365,13 @@ def _init_postgresql(conn):
             conta_id INTEGER REFERENCES contas(id),
             criado_em TEXT NOT NULL,
             atualizado_em TEXT
+        )
+    ''')
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS push_subscriptions (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            endpoint TEXT NOT NULL,
+            subscription_json TEXT NOT NULL
         )
     ''')

--- a/app/routes/push.py
+++ b/app/routes/push.py
@@ -1,0 +1,101 @@
+from flask import Blueprint, request, jsonify
+import json
+import os
+from app.database import db_connection
+from app.utils import erro_json, validar_csrf, login_required, get_current_user_id
+
+bp = Blueprint('push', __name__)
+
+
+@bp.route('/api/push/vapid-key')
+@login_required
+def vapid_public_key():
+    key = os.getenv('VAPID_PUBLIC_KEY', '')
+    if not key:
+        return erro_json('Push não configurado.', 503)
+    return jsonify({'publicKey': key})
+
+
+@bp.route('/api/push/subscribe', methods=['POST'])
+@login_required
+def subscribe():
+    if not validar_csrf():
+        return erro_json('CSRF inválido.', 403)
+    data = request.json or {}
+    subscription = data.get('subscription')
+    if not subscription or not subscription.get('endpoint'):
+        return erro_json('Subscription inválida.', 400)
+
+    user_id = get_current_user_id()
+    endpoint = subscription['endpoint']
+    sub_json = json.dumps(subscription)
+
+    with db_connection() as conn:
+        existing = conn.execute("SELECT id FROM push_subscriptions WHERE user_id = ? AND endpoint = ?", (user_id, endpoint)).fetchone()
+        if existing:
+            conn.execute("UPDATE push_subscriptions SET subscription_json = ? WHERE id = ?", (sub_json, existing[0]))
+        else:
+            conn.execute("INSERT INTO push_subscriptions (user_id, endpoint, subscription_json) VALUES (?,?,?)",
+                (user_id, endpoint, sub_json))
+    return jsonify({'status': 'ok'})
+
+
+@bp.route('/api/push/unsubscribe', methods=['POST'])
+@login_required
+def unsubscribe():
+    if not validar_csrf():
+        return erro_json('CSRF inválido.', 403)
+    data = request.json or {}
+    endpoint = data.get('endpoint', '')
+    user_id = get_current_user_id()
+    with db_connection() as conn:
+        conn.execute("DELETE FROM push_subscriptions WHERE user_id = ? AND endpoint = ?", (user_id, endpoint))
+    return jsonify({'status': 'ok'})
+
+
+@bp.route('/api/push/test', methods=['POST'])
+@login_required
+def test_push():
+    """Envia uma notificação de teste para o usuário atual."""
+    if not validar_csrf():
+        return erro_json('CSRF inválido.', 403)
+    user_id = get_current_user_id()
+    sent = _send_to_user(user_id, 'FinanZen', 'Notificações ativadas com sucesso! 🎉')
+    return jsonify({'status': 'ok', 'sent': sent})
+
+
+def _send_to_user(user_id, title, body, url='/dashboard'):
+    """Envia push para todas as subscriptions de um usuário."""
+    vapid_private = os.getenv('VAPID_PRIVATE_KEY', '')
+    vapid_email = os.getenv('VAPID_EMAIL', 'mailto:admin@finanzen.app')
+    if not vapid_private:
+        return 0
+
+    try:
+        from pywebpush import webpush, WebPushException
+    except ImportError:
+        return 0
+
+    with db_connection() as conn:
+        rows = conn.execute("SELECT id, subscription_json FROM push_subscriptions WHERE user_id = ?", (user_id,)).fetchall()
+
+    payload = json.dumps({'title': title, 'body': body, 'url': url})
+    sent = 0
+    expired_ids = []
+
+    for row in rows:
+        sub = json.loads(row[1])
+        try:
+            webpush(sub, payload, vapid_private_key=vapid_private,
+                    vapid_claims={'sub': vapid_email})
+            sent += 1
+        except WebPushException as e:
+            if e.response and e.response.status_code in (404, 410):
+                expired_ids.append(row[0])
+
+    if expired_ids:
+        with db_connection() as conn:
+            for eid in expired_ids:
+                conn.execute("DELETE FROM push_subscriptions WHERE id = ?", (eid,))
+
+    return sent

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas==2.2.3
 requests==2.32.3
 gunicorn==22.0.0
 psycopg2-binary==2.9.10
+pywebpush==2.0.1

--- a/static/script.js
+++ b/static/script.js
@@ -866,4 +866,42 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   loadConexoes();
+
+  // ── Push Notifications ──
+  async function initPush() {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+    const reg = await navigator.serviceWorker.ready;
+    const existing = await reg.pushManager.getSubscription();
+    if (existing) return; // já inscrito
+
+    // Pedir permissão após 5s na página
+    setTimeout(async () => {
+      const perm = await Notification.requestPermission();
+      if (perm !== 'granted') return;
+
+      const res = await fetch('/api/push/vapid-key');
+      if (!res.ok) return;
+      const { publicKey } = await res.json();
+
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(publicKey)
+      });
+
+      await fetch('/api/push/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+        body: JSON.stringify({ subscription: sub.toJSON() })
+      });
+    }, 5000);
+  }
+
+  function urlBase64ToUint8Array(base64String) {
+    const padding = '='.repeat((4 - base64String.length % 4) % 4);
+    const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const raw = atob(base64);
+    return Uint8Array.from([...raw].map(c => c.charCodeAt(0)));
+  }
+
+  initPush();
 });

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,8 +1,39 @@
-const CACHE = 'finanzen-v1';
+const CACHE = 'finanzen-v2';
 const ASSETS = ['/static/style.css', '/static/script.js', '/static/form.js', '/static/lancamentos.js', '/static/brand/logo-finanzen.svg', '/static/brand/favicon-finanzen.svg'];
 
-self.addEventListener('install', e => e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS))));
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))));
+});
+
 self.addEventListener('fetch', e => {
   if (e.request.method !== 'GET') return;
   e.respondWith(fetch(e.request).catch(() => caches.match(e.request)));
+});
+
+self.addEventListener('push', e => {
+  const data = e.data ? e.data.json() : {};
+  const title = data.title || 'FinanZen';
+  const options = {
+    body: data.body || '',
+    icon: '/static/brand/favicon-finanzen.svg',
+    badge: '/static/brand/favicon-finanzen.svg',
+    data: { url: data.url || '/dashboard' }
+  };
+  e.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', e => {
+  e.notification.close();
+  const url = e.notification.data?.url || '/dashboard';
+  e.waitUntil(clients.matchAll({ type: 'window' }).then(list => {
+    for (const client of list) {
+      if (client.url.includes(url) && 'focus' in client) return client.focus();
+    }
+    return clients.openWindow(url);
+  }));
 });


### PR DESCRIPTION
## Roadmap 6.2 — Notificações Push

- Web Push API com VAPID keys (configurar env vars no Render)
- Service worker recebe push e abre app no click
- Frontend pede permissão e se inscreve automaticamente
- Endpoint de teste: POST /api/push/test

### Configuração no Render
Gerar VAPID keys: `npx web-push generate-vapid-keys`
Adicionar env vars:
- `VAPID_PUBLIC_KEY`
- `VAPID_PRIVATE_KEY`
- `VAPID_EMAIL` (mailto:seu@email.com)

### 50 testes passando