### PR TITLE
feat: dashboard mobile-first

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -3,6 +3,19 @@ document.addEventListener("DOMContentLoaded", () => {
   const html = document.documentElement;
   const body = document.body;
   const dados = body?.dataset?.dados ? JSON.parse(body.dataset.dados) : [];
+
+  // ── Pull-to-refresh (mobile) ──
+  let pullStartY = 0;
+  let pulling = false;
+  document.addEventListener('touchstart', e => {
+    if (window.scrollY === 0) { pullStartY = e.touches[0].clientY; pulling = true; }
+  });
+  document.addEventListener('touchmove', e => {
+    if (!pulling) return;
+    const diff = e.touches[0].clientY - pullStartY;
+    if (diff > 120) { pulling = false; window.location.reload(); }
+  });
+  document.addEventListener('touchend', () => { pulling = false; });
   const savedTheme = localStorage.getItem('theme');
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
   const avatarTrigger = document.getElementById('avatar-trigger');

--- a/static/style.css
+++ b/static/style.css
@@ -1012,19 +1012,66 @@ select:focus-visible,
 }
 
 @media (max-width: 560px) {
-  .app-shell { width: min(1120px, 100% - 0.75rem); margin-top: 0.5rem; }
+  .app-shell { width: min(1120px, 100% - 0.75rem); margin-top: 0.5rem; margin-bottom: 4.5rem; }
   .glass-container { padding: 0.85rem; border-radius: 16px; }
   .formulario { grid-template-columns: 1fr; }
-  .valor-boxes { grid-template-columns: 1fr; }
-  .valor-box { padding: 0.75rem; }
+  .valor-boxes { grid-template-columns: 1fr 1fr 1fr; gap: 0.5rem; overflow-x: auto; scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch; flex-wrap: nowrap; padding-bottom: 0.25rem; }
+  .valor-box { padding: 0.75rem; scroll-snap-align: start; min-width: 0; }
   :root { --field-height: 42px; --field-font-size: 0.875rem; }
-  .fab-novo { display: inline-flex; align-items: center; justify-content: center; }
+  .fab-novo { display: inline-flex; align-items: center; justify-content: center; bottom: 5.5rem; }
   #busca-lancamentos { max-width: 100%; }
   .graficos-grid { grid-template-columns: 1fr; }
   .chart-wrap { height: 200px; }
   #form-perfil { grid-template-columns: 1fr; }
-  .top-tabs { gap: 1px; padding: 2px; }
+  .top-tabs { display: none; }
+  .bottom-nav { display: flex; }
+  .global-header { grid-template-columns: 1fr auto; }
+  .global-brand { justify-self: start; }
   .top-tab { font-size: 0.75rem; padding: 0.35rem 0.6rem; }
+}
+
+/* ── Bottom Navigation ── */
+.bottom-nav {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: var(--glass-bg-elevated);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-top: 0.5px solid var(--glass-border-subtle);
+  padding: 0.5rem 0 calc(0.5rem + env(safe-area-inset-bottom));
+  justify-content: space-around;
+  align-items: center;
+}
+
+.bottom-nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  text-decoration: none;
+  color: var(--text-tertiary);
+  font-size: 0.65rem;
+  font-weight: 500;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-md);
+  transition: color var(--duration-fast);
+}
+
+.bottom-nav-item.is-active {
+  color: var(--accent);
+}
+
+.bottom-nav-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.bottom-nav-label {
+  line-height: 1;
 }
 
 /* ── Reduced motion ── */

--- a/templates/index.html
+++ b/templates/index.html
@@ -628,6 +628,19 @@
     </main>
   </div>
 
+  <!-- Bottom Navigation (mobile) -->
+  <nav class="bottom-nav" aria-label="Navegação mobile">
+    <a href="/dashboard" class="bottom-nav-item {{ 'is-active' if active_tab == 'dashboard' else '' }}">
+      <span class="bottom-nav-icon">📊</span><span class="bottom-nav-label">Dashboard</span>
+    </a>
+    <a href="/lancamentos" class="bottom-nav-item {{ 'is-active' if active_tab == 'lancamentos' else '' }}">
+      <span class="bottom-nav-icon">💸</span><span class="bottom-nav-label">Lançamentos</span>
+    </a>
+    <a href="/relatorios" class="bottom-nav-item {{ 'is-active' if active_tab == 'relatorios' else '' }}">
+      <span class="bottom-nav-icon">📈</span><span class="bottom-nav-label">Relatórios</span>
+    </a>
+  </nav>
+
   <script src="{{ url_for('static', filename='script.js') }}"></script>
   <script src="{{ url_for('static', filename='form.js') }}"></script>
   <script src="{{ url_for('static', filename='lancamentos.js') }}"></script>


### PR DESCRIPTION
## Roadmap 6.3

- Bottom nav bar no mobile (substitui top tabs em telas <560px)
- Cards de resumo com scroll snap horizontal
- Pull-to-refresh via touch
- FAB acima da bottom nav
- Safe area para notch/home indicator do iPhone