### PR TITLE
feat: modo família + revisão UI Liquid Glass

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,8 +19,8 @@ def create_app():
         os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
     os.makedirs(os.path.join(flask_app.static_folder, 'uploads', 'avatars'), exist_ok=True)
 
-    from app.routes import auth, lancamentos, orcamentos, metas, relatorios, contas, social, pluggy, ia, importacao, onboarding, push, planejamento
-    for bp in [auth.bp, lancamentos.bp, orcamentos.bp, metas.bp, relatorios.bp, contas.bp, social.bp, pluggy.bp, ia.bp, importacao.bp, onboarding.bp, push.bp, planejamento.bp]:
+    from app.routes import auth, lancamentos, orcamentos, metas, relatorios, contas, social, pluggy, ia, importacao, onboarding, push, planejamento, familia
+    for bp in [auth.bp, lancamentos.bp, orcamentos.bp, metas.bp, relatorios.bp, contas.bp, social.bp, pluggy.bp, ia.bp, importacao.bp, onboarding.bp, push.bp, planejamento.bp, familia.bp]:
         flask_app.register_blueprint(bp)
 
     init_db()

--- a/app/routes/familia.py
+++ b/app/routes/familia.py
@@ -1,0 +1,134 @@
+from flask import Blueprint, request, jsonify, render_template
+from datetime import datetime
+from app.database import db_connection, sql
+from app.utils import erro_json, login_required, get_current_user_id, get_current_user, common_template_context
+
+bp = Blueprint('familia', __name__)
+
+
+@bp.route('/familia')
+@login_required
+def familia_page():
+    user = get_current_user()
+    context = common_template_context(user, 'familia')
+    return render_template('familia.html', dados=[], saldo=0, entrada=0, saida=0, **context)
+
+
+def _get_family_members(user_id):
+    """Returns user IDs of family members (bidirectional 'escrita' sharing)."""
+    with db_connection() as conn:
+        # Users I shared with (escrita) + users who shared with me (escrita)
+        shared_by_me = conn.execute(
+            "SELECT shared_with_id FROM compartilhamentos WHERE owner_id = ? AND permissao = 'escrita'",
+            (user_id,)).fetchall()
+        shared_with_me = conn.execute(
+            "SELECT owner_id FROM compartilhamentos WHERE shared_with_id = ? AND permissao = 'escrita'",
+            (user_id,)).fetchall()
+    members = set([r[0] for r in shared_by_me] + [r[0] for r in shared_with_me])
+    members.add(user_id)
+    return list(members)
+
+
+@bp.route('/api/familia/membros')
+@login_required
+def membros():
+    user_id = get_current_user_id()
+    member_ids = _get_family_members(user_id)
+    if len(member_ids) <= 1:
+        return jsonify({'membros': [], 'msg': 'Nenhum membro familiar. Compartilhe com permissão "escrita" para criar sua família.'})
+    with db_connection() as conn:
+        placeholders = ','.join(['?'] * len(member_ids))
+        rows = conn.execute(
+            f"SELECT id, name, nickname, avatar_url FROM users WHERE id IN ({placeholders})",
+            member_ids).fetchall()
+    membros = [{'id': r[0], 'nome': r[2] or r[1], 'avatar_url': r[3] or ''} for r in rows]
+    return jsonify({'membros': membros})
+
+
+@bp.route('/api/familia/resumo')
+@login_required
+def resumo():
+    user_id = get_current_user_id()
+    member_ids = _get_family_members(user_id)
+    if len(member_ids) <= 1:
+        return erro_json('Nenhum membro familiar encontrado.', 404)
+
+    mes = request.args.get('mes') or datetime.now().strftime('%Y-%m')
+    placeholders = ','.join(['?'] * len(member_ids))
+
+    with db_connection() as conn:
+        # Gastos por membro
+        rows = conn.execute(
+            sql(f"SELECT user_id, tipo, SUM(valor) FROM lancamentos WHERE user_id IN ({placeholders}) AND strftime('%Y-%m', data) = ? GROUP BY user_id, tipo"),
+            member_ids + [mes]).fetchall()
+
+        # Nomes
+        users = conn.execute(
+            f"SELECT id, name, nickname FROM users WHERE id IN ({placeholders})",
+            member_ids).fetchall()
+
+    user_map = {r[0]: r[2] or r[1] for r in users}
+    tipos_saida = {'saida', 'divida', 'conta'}
+
+    with db_connection() as conn:
+        orc = conn.execute(
+            f"SELECT COALESCE(SUM(limite), 0) FROM orcamentos WHERE user_id IN ({placeholders}) AND mes = ?",
+            member_ids + [mes]).fetchone()
+
+    por_membro = {}
+    total_entradas = total_saidas = 0
+    for r in rows:
+        uid, tipo, valor = r[0], r[1], r[2]
+        if uid not in por_membro:
+            por_membro[uid] = {'nome': user_map.get(uid, ''), 'entradas': 0, 'saidas': 0}
+        if tipo in tipos_saida:
+            por_membro[uid]['saidas'] += valor
+            total_saidas += valor
+        else:
+            por_membro[uid]['entradas'] += valor
+            total_entradas += valor
+
+    return jsonify({
+        'mes': mes,
+        'total_entradas': round(total_entradas, 2),
+        'total_saidas': round(total_saidas, 2),
+        'saldo': round(total_entradas - total_saidas, 2),
+        'orcamento_familiar': round(orc[0], 2) if orc else 0,
+        'por_membro': [{'id': uid, **data, 'entradas': round(data['entradas'], 2), 'saidas': round(data['saidas'], 2)} for uid, data in por_membro.items()]
+    })
+
+
+@bp.route('/api/familia/gastos-categoria')
+@login_required
+def gastos_categoria():
+    user_id = get_current_user_id()
+    member_ids = _get_family_members(user_id)
+    if len(member_ids) <= 1:
+        return erro_json('Nenhum membro familiar encontrado.', 404)
+
+    mes = request.args.get('mes') or datetime.now().strftime('%Y-%m')
+    placeholders = ','.join(['?'] * len(member_ids))
+
+    with db_connection() as conn:
+        rows = conn.execute(
+            sql(f"SELECT user_id, categoria, SUM(valor) FROM lancamentos WHERE user_id IN ({placeholders}) AND strftime('%Y-%m', data) = ? AND tipo IN ('saida','divida','conta') GROUP BY user_id, categoria ORDER BY SUM(valor) DESC"),
+            member_ids + [mes]).fetchall()
+        users = conn.execute(
+            f"SELECT id, name, nickname FROM users WHERE id IN ({placeholders})",
+            member_ids).fetchall()
+
+    user_map = {r[0]: r[2] or r[1] for r in users}
+
+    # Consolidado por categoria
+    por_categoria = {}
+    for r in rows:
+        cat = r[1] or 'Sem categoria'
+        if cat not in por_categoria:
+            por_categoria[cat] = {'total': 0, 'membros': []}
+        por_categoria[cat]['total'] += r[2]
+        por_categoria[cat]['membros'].append({'nome': user_map.get(r[0], ''), 'valor': round(r[2], 2)})
+
+    categorias = [{'categoria': k, 'total': round(v['total'], 2), 'membros': v['membros']}
+                  for k, v in sorted(por_categoria.items(), key=lambda x: -x[1]['total'])]
+
+    return jsonify({'mes': mes, 'categorias': categorias})

--- a/static/familia.js
+++ b/static/familia.js
@@ -1,0 +1,117 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const section = document.getElementById('familia-section');
+  if (!section) return;
+
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+  const membrosEl = document.getElementById('familia-membros');
+  const resumoEl = document.getElementById('familia-resumo');
+  const categoriasEl = document.getElementById('familia-categorias');
+  const canvas = document.getElementById('graficoFamilia');
+  let familiaChart = null;
+
+  async function loadFamilia() {
+    const [membrosRes, resumoRes, catRes] = await Promise.all([
+      fetch('/api/familia/membros'),
+      fetch('/api/familia/resumo'),
+      fetch('/api/familia/gastos-categoria')
+    ]);
+
+    const membrosData = await membrosRes.json();
+    const resumoData = await resumoRes.json();
+    const catData = await catRes.json();
+
+    renderMembros(membrosData);
+    renderResumo(resumoData);
+    renderCategorias(catData);
+    renderChart(resumoData);
+  }
+
+  function renderMembros(data) {
+    if (!data.membros || data.membros.length === 0) {
+      membrosEl.innerHTML = `<div class="empty-state"><div class="empty-state-icon">👨‍👩‍👧‍👦</div><p>${data.msg || 'Nenhum membro familiar. Compartilhe com permissão "escrita" para criar sua família.'}</p></div>`;
+      resumoEl.innerHTML = '';
+      categoriasEl.innerHTML = '';
+      canvas.style.display = 'none';
+      return;
+    }
+    membrosEl.innerHTML = `<div class="familia-avatars">${data.membros.map(m =>
+      `<div class="familia-avatar-item"><span class="avatar-fallback">${m.nome[0].toUpperCase()}</span><small>${m.nome}</small></div>`
+    ).join('')}</div>`;
+  }
+
+  function renderResumo(data) {
+    if (data.erro) return;
+    resumoEl.innerHTML = `
+      <div class="valor-boxes">
+        <div class="valor-box">Entradas<br><strong style="color:var(--color-green)">R$ ${data.total_entradas?.toFixed(2) || '0.00'}</strong></div>
+        <div class="valor-box">Saídas<br><strong style="color:var(--color-red)">R$ ${data.total_saidas?.toFixed(2) || '0.00'}</strong></div>
+        <div class="valor-box">Saldo<br><strong>R$ ${data.saldo?.toFixed(2) || '0.00'}</strong></div>
+        ${data.orcamento_familiar ? `<div class="valor-box">Orçamento<br><strong>R$ ${data.orcamento_familiar.toFixed(2)}</strong></div>` : ''}
+      </div>
+      <div class="familia-membros-gastos">
+        <h3>Gastos por membro</h3>
+        <div class="familia-membros-list">
+          ${(data.por_membro || []).map(m => `
+            <div class="familia-membro-row">
+              <span class="familia-membro-nome">${m.nome}</span>
+              <span class="familia-membro-valor text-red">- R$ ${m.saidas.toFixed(2)}</span>
+              <span class="familia-membro-valor text-green">+ R$ ${m.entradas.toFixed(2)}</span>
+            </div>
+          `).join('')}
+        </div>
+      </div>`;
+  }
+
+  function renderCategorias(data) {
+    if (data.erro || !data.categorias) return;
+    categoriasEl.innerHTML = `
+      <h3>Gastos por categoria</h3>
+      <div class="familia-cat-list">
+        ${data.categorias.map(c => `
+          <div class="familia-cat-item">
+            <div class="familia-cat-header">
+              <span>${c.categoria}</span>
+              <strong>R$ ${c.total.toFixed(2)}</strong>
+            </div>
+            <div class="familia-cat-membros">
+              ${c.membros.map(m => `<small>${m.nome}: R$ ${m.valor.toFixed(2)}</small>`).join(' · ')}
+            </div>
+          </div>
+        `).join('')}
+      </div>`;
+  }
+
+  function renderChart(data) {
+    if (data.erro || !data.por_membro || data.por_membro.length === 0) {
+      canvas.style.display = 'none';
+      return;
+    }
+    canvas.style.display = '';
+    const theme = document.documentElement.getAttribute('data-theme');
+    const textColor = theme === 'dark' ? '#f5f5f7' : '#1c1c1e';
+    const gridColor = theme === 'dark' ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
+
+    if (familiaChart) familiaChart.destroy();
+    familiaChart = new Chart(canvas, {
+      type: 'bar',
+      data: {
+        labels: data.por_membro.map(m => m.nome),
+        datasets: [
+          { label: 'Entradas', data: data.por_membro.map(m => m.entradas), backgroundColor: theme === 'dark' ? '#30d158' : '#34c759', borderRadius: 6 },
+          { label: 'Saídas', data: data.por_membro.map(m => m.saidas), backgroundColor: theme === 'dark' ? '#ff453a' : '#ff3b30', borderRadius: 6 }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { labels: { color: textColor, font: { family: '-apple-system, BlinkMacSystemFont, SF Pro Display, Inter, sans-serif', weight: 600, size: 12 } } } },
+        scales: {
+          x: { ticks: { color: textColor, font: { size: 11 } }, grid: { color: gridColor } },
+          y: { ticks: { color: textColor, font: { size: 11 }, callback: v => 'R$ ' + v }, grid: { color: gridColor } }
+        }
+      }
+    });
+  }
+
+  loadFamilia();
+});

--- a/static/style.css
+++ b/static/style.css
@@ -504,7 +504,7 @@ body {
 /* ── Value Boxes — Apple Widgets style ── */
 .valor-boxes {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: var(--space-3);
   margin-bottom: var(--space-4);
 }
@@ -898,6 +898,22 @@ select:focus-visible,
 
 /* ── Auth pages ── */
 .auth-card { max-width: 480px; margin: 0 auto; }
+
+.auth-card h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin: 0 0 0.25rem;
+  color: var(--text-primary);
+}
+
+.auth-card .subtitle {
+  margin: 0 0 1.5rem;
+}
+
+.auth-card .botao-principal {
+  grid-column: 1 / -1;
+}
 
 .auth-brand {
   display: block;
@@ -1307,3 +1323,22 @@ select:focus-visible,
 
 .sugestao-cat:hover { text-decoration: underline; }
 .sugestao-cat.visible { display: block; }
+
+/* ── Família ── */
+.familia-avatars { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+.familia-avatar-item { display: flex; flex-direction: column; align-items: center; gap: 0.3rem; }
+.familia-avatar-item .avatar-fallback { width: 48px; height: 48px; border-radius: 50%; background: var(--accent); color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 1.2rem; border: 0.5px solid var(--glass-border); box-shadow: var(--glass-shadow); }
+.familia-avatar-item small { font-size: 0.75rem; color: var(--text-tertiary); font-weight: 500; }
+.familia-membros-gastos { margin-top: 1.5rem; }
+.familia-membros-gastos h3, .familia-categorias h3 { margin-bottom: 0.75rem; font-size: 1.0625rem; font-weight: 650; color: var(--text-primary); letter-spacing: -0.02em; }
+.familia-membros-list { display: flex; flex-direction: column; gap: 0.5rem; }
+.familia-membro-row { display: flex; align-items: center; gap: 1rem; padding: 0.6rem 0.85rem; border-radius: var(--radius-sm); background: var(--glass-bg-elevated); border: 0.5px solid var(--glass-border-subtle); transition: transform var(--duration-fast) var(--ease-spring); }
+.familia-membro-row:hover { transform: translateX(2px); }
+.familia-membro-nome { flex: 1; font-weight: 600; font-size: 0.875rem; }
+.familia-membro-valor { font-size: 0.875rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+.familia-cat-list { display: flex; flex-direction: column; gap: 0.6rem; margin-top: 0.75rem; }
+.familia-cat-item { padding: 0.75rem 0.85rem; border-radius: var(--radius-sm); background: var(--glass-bg-elevated); border: 0.5px solid var(--glass-border-subtle); transition: transform var(--duration-fast) var(--ease-spring); }
+.familia-cat-item:hover { transform: translateY(-1px); }
+.familia-cat-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.25rem; font-weight: 600; font-size: 0.875rem; }
+.familia-cat-membros { font-size: 0.8125rem; color: var(--text-tertiary); }
+.familia-categorias h3 { margin-top: 1.5rem; }

--- a/templates/familia.html
+++ b/templates/familia.html
@@ -1,0 +1,1 @@
+{% include 'index.html' %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,6 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="theme-color" content="#007aff" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <script src="https://cdn.pluggy.ai/pluggy-connect.js" async></script>
@@ -27,6 +26,7 @@
         <a href="/dashboard" data-tab="dashboard" class="top-tab {{ 'is-active' if active_tab == 'dashboard' else '' }}">Dashboard</a>
         <a href="/lancamentos" data-tab="lancamentos" class="top-tab {{ 'is-active' if active_tab == 'lancamentos' else '' }}">Lançamentos</a>
         <a href="/relatorios" data-tab="relatorios" class="top-tab {{ 'is-active' if active_tab == 'relatorios' else '' }}">Relatórios</a>
+        <a href="/familia" data-tab="familia" class="top-tab {{ 'is-active' if active_tab == 'familia' else '' }}">Família</a>
       </nav>
       <div class="header-acoes">
         <button id="toggle-theme" class="botao-tema botao-tema--icon" aria-label="Alternar tema de cores" aria-pressed="false">🌙</button>
@@ -398,6 +398,19 @@
       </section>
       {% endif %}
 
+      {% if active_tab == 'familia' %}
+      <section class="glass-card section-block" id="familia-section">
+        <div class="section-head-inline">
+          <h2>👨‍👩‍👧‍👦 Visão Familiar</h2>
+          <p>Gastos consolidados de todos os membros da família.</p>
+        </div>
+        <div id="familia-membros" class="familia-membros"></div>
+        <div id="familia-resumo" class="familia-resumo"></div>
+        <div class="chart-wrap"><canvas id="graficoFamilia" aria-label="Gastos por membro da família" role="img"></canvas></div>
+        <div id="familia-categorias" class="familia-categorias"></div>
+      </section>
+      {% endif %}
+
       <section id="modal-edicao" class="modal" aria-hidden="true" role="dialog" aria-labelledby="modal-title" aria-modal="true">
         <div class="modal__backdrop" data-close-modal="true"></div>
         <div class="modal__content glass-card">
@@ -639,10 +652,14 @@
     <a href="/relatorios" class="bottom-nav-item {{ 'is-active' if active_tab == 'relatorios' else '' }}">
       <span class="bottom-nav-icon">📈</span><span class="bottom-nav-label">Relatórios</span>
     </a>
+    <a href="/familia" class="bottom-nav-item {{ 'is-active' if active_tab == 'familia' else '' }}">
+      <span class="bottom-nav-icon">👨‍👩‍👧‍👦</span><span class="bottom-nav-label">Família</span>
+    </a>
   </nav>
 
   <script src="{{ url_for('static', filename='script.js') }}"></script>
   <script src="{{ url_for('static', filename='form.js') }}"></script>
   <script src="{{ url_for('static', filename='lancamentos.js') }}"></script>
+  <script src="{{ url_for('static', filename='familia.js') }}"></script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Login • FinanZen</title>
   <link rel="icon" href="{{ url_for('static', filename='brand/favicon-finanzen.svg') }}" type="image/svg+xml" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
 <body>

--- a/templates/onboarding.html
+++ b/templates/onboarding.html
@@ -6,17 +6,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Bem-vindo • FinanZen</title>
   <link rel="icon" href="{{ url_for('static', filename='brand/favicon-finanzen.svg') }}" type="image/svg+xml" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   <style>
     .onboarding { max-width: 520px; margin: 2rem auto; padding: 0 1rem; }
-    .onboarding h1 { text-align: center; margin-bottom: 0.5rem; }
-    .onboarding .subtitle { text-align: center; opacity: 0.7; margin-bottom: 2rem; }
+    .onboarding h1 { text-align: center; margin-bottom: 0.5rem; font-size: 1.5rem; font-weight: 700; letter-spacing: -0.03em; }
+    .onboarding .subtitle { text-align: center; color: var(--text-tertiary); margin-bottom: 2rem; }
     .step { display: none; }
     .step.active { display: block; }
     .step-indicator { display: flex; justify-content: center; gap: 0.5rem; margin-bottom: 1.5rem; }
-    .step-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--glass-border); transition: background 0.3s; }
-    .step-dot.active { background: var(--accent); }
+    .step-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--glass-border); transition: background var(--duration-normal) var(--ease-spring); }
+    .step-dot.active { background: var(--accent); box-shadow: 0 0 6px rgba(0, 122, 255, 0.3); }
+    .step-hint { color: var(--text-tertiary); font-size: 0.875rem; margin: 0.25rem 0 1rem; }
     .contas-fixas-list, .orcamentos-list { display: flex; flex-direction: column; gap: 0.75rem; }
     .conta-fixa-row, .orcamento-row { display: grid; grid-template-columns: 1fr 120px; gap: 0.5rem; }
     .conta-fixa-row input,
@@ -54,8 +54,10 @@
       background-repeat: no-repeat;
     }
     .onboarding-actions { display: flex; justify-content: space-between; margin-top: 1.5rem; }
-    .btn-add { background: none; border: 1px dashed var(--glass-border); padding: 0.5rem; border-radius: var(--radius-md); cursor: pointer; color: var(--accent); font-size: 0.85rem; margin-top: 0.5rem; width: 100%; }
-    .btn-skip { background: none; border: none; color: var(--text-secondary); cursor: pointer; font-size: 0.9rem; }
+    .btn-add { background: none; border: 0.5px dashed var(--glass-border); padding: 0.5rem; border-radius: var(--radius-md); cursor: pointer; color: var(--accent); font-size: 0.85rem; font-weight: 600; margin-top: 0.5rem; width: 100%; transition: all var(--duration-fast) var(--ease-spring); }
+    .btn-add:hover { background: rgba(0, 122, 255, 0.06); border-color: var(--accent); }
+    .btn-skip { background: none; border: none; color: var(--text-tertiary); cursor: pointer; font-size: 0.875rem; font-weight: 500; transition: color var(--duration-fast); }
+    .btn-skip:hover { color: var(--text-primary); }
   </style>
 </head>
 <body>
@@ -74,7 +76,7 @@
         <!-- Passo 1: Renda -->
         <section class="step active glass-card section-block" data-step="1">
           <h2>💰 Qual sua renda mensal?</h2>
-          <p style="opacity:0.7;font-size:0.9rem;">Isso nos ajuda a calcular sua taxa de poupança.</p>
+          <p class="step-hint">Isso nos ajuda a calcular sua taxa de poupança.</p>
           <div class="campo-form">
             <label for="renda">Renda líquida (R$)</label>
             <input type="number" id="renda" min="0" step="0.01" placeholder="5000.00" />
@@ -88,7 +90,7 @@
         <!-- Passo 2: Contas fixas -->
         <section class="step glass-card section-block" data-step="2">
           <h2>🏠 Quais suas contas fixas?</h2>
-          <p style="opacity:0.7;font-size:0.9rem;">Aluguel, internet, luz... Adicionamos como recorrentes.</p>
+          <p class="step-hint">Aluguel, internet, luz... Adicionamos como recorrentes.</p>
           <div class="contas-fixas-list" id="contas-fixas-list">
             <div class="conta-fixa-row">
               <input type="text" placeholder="Ex: Aluguel" class="cf-nome" />
@@ -105,7 +107,7 @@
         <!-- Passo 3: Orçamentos -->
         <section class="step glass-card section-block" data-step="3">
           <h2>📊 Defina seus orçamentos</h2>
-          <p style="opacity:0.7;font-size:0.9rem;">Quanto quer gastar por categoria este mês?</p>
+          <p class="step-hint">Quanto quer gastar por categoria este mês?</p>
           <div class="orcamentos-list" id="orcamentos-list">
             <div class="orcamento-row">
               <select class="orc-cat">

--- a/templates/register.html
+++ b/templates/register.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Cadastro • FinanZen</title>
   <link rel="icon" href="{{ url_for('static', filename='brand/favicon-finanzen.svg') }}" type="image/svg+xml" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
 <body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -575,3 +575,89 @@ class FinancialAppIntegrationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FamiliaTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test.db")
+        os.environ["SECRET_KEY"] = "test-secret-key"
+
+        import app.config as config
+        import app.database as database
+        config.DB_PATH = self.db_path
+        database.DB_PATH = self.db_path
+
+        from app import create_app
+        flask_app = create_app()
+        flask_app.config["TESTING"] = True
+        flask_app.secret_key = "test-secret-key"
+        self.flask_app = flask_app
+        self.client = flask_app.test_client()
+
+        # Create user 1
+        self.client.post("/cadastro", data={"name": "User1", "email": "user1@test.com", "password": "SenhaForte123", "password_confirm": "SenhaForte123"})
+        self.client.post("/login", data={"email": "user1@test.com", "password": "SenhaForte123"})
+        self.client.get("/dashboard")
+        with self.client.session_transaction() as sess:
+            self.csrf1 = sess.get("csrf_token")
+            self.user1_id = sess.get("user_id")
+
+        # Create user 2
+        self.client2 = flask_app.test_client()
+        self.client2.post("/cadastro", data={"name": "User2", "email": "user2@test.com", "password": "SenhaForte123", "password_confirm": "SenhaForte123"})
+        self.client2.post("/login", data={"email": "user2@test.com", "password": "SenhaForte123"})
+        self.client2.get("/dashboard")
+        with self.client2.session_transaction() as sess:
+            self.csrf2 = sess.get("csrf_token")
+            self.user2_id = sess.get("user_id")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _h(self, csrf):
+        return {"Content-Type": "application/json", "X-CSRF-Token": csrf}
+
+    def test_membros_sem_familia(self):
+        resp = self.client.get("/api/familia/membros")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json["membros"], [])
+
+    def test_resumo_sem_familia(self):
+        resp = self.client.get("/api/familia/resumo")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_familia_com_compartilhamento_escrita(self):
+        # User1 shares with User2 (escrita)
+        self.client.post("/api/compartilhar", json={"email": "user2@test.com", "permissao": "escrita"}, headers=self._h(self.csrf1))
+
+        # Add lancamento for user1
+        self.client.post("/lancamento", json={"data": "2026-05-01", "tipo": "saida", "descricao": "Mercado", "valor": 200}, headers=self._h(self.csrf1))
+        # Add lancamento for user2
+        self.client2.post("/lancamento", json={"data": "2026-05-01", "tipo": "saida", "descricao": "Farmácia", "valor": 50}, headers=self._h(self.csrf2))
+
+        # User2 should see family
+        resp = self.client2.get("/api/familia/membros")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json["membros"]), 2)
+
+        # Resumo
+        resp = self.client2.get("/api/familia/resumo?mes=2026-05")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json["total_saidas"], 250.0)
+
+    def test_familia_gastos_categoria(self):
+        self.client.post("/api/compartilhar", json={"email": "user2@test.com", "permissao": "escrita"}, headers=self._h(self.csrf1))
+        self.client.post("/lancamento", json={"data": "2026-05-01", "tipo": "saida", "descricao": "Mercado", "valor": 100, "categoria": "Alimentação"}, headers=self._h(self.csrf1))
+        self.client2.post("/lancamento", json={"data": "2026-05-01", "tipo": "saida", "descricao": "Restaurante", "valor": 80, "categoria": "Alimentação"}, headers=self._h(self.csrf2))
+
+        resp = self.client.get("/api/familia/gastos-categoria?mes=2026-05")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json["categorias"][0]["categoria"], "Alimentação")
+        self.assertEqual(resp.json["categorias"][0]["total"], 180.0)
+
+    def test_leitura_nao_cria_familia(self):
+        # Compartilhamento com leitura não deve criar família
+        self.client.post("/api/compartilhar", json={"email": "user2@test.com", "permissao": "leitura"}, headers=self._h(self.csrf1))
+        resp = self.client2.get("/api/familia/membros")
+        self.assertEqual(resp.json["membros"], [])


### PR DESCRIPTION
## Resumo

Implementa a **Fase 7.1 (Modo Família)** do roadmap e faz revisão geral de UI para conformidade com o design system Liquid Glass (iOS 26/macOS Tahoe).

## Mudanças

### Modo Família
- 3 endpoints API: `/api/familia/membros`, `/api/familia/resumo`, `/api/familia/gastos-categoria`
- Rota `/familia` com dashboard consolidado familiar
- Gráfico de barras entradas vs saídas por membro (Chart.js)
- Gastos por categoria com breakdown de quem gastou o quê
- Lógica: compartilhamento com permissão "escrita" (bidirecional) define família
- Aba na navegação top e bottom (mobile)

### Revisão UI
- Remove Google Fonts (usa `-apple-system` nativo — mais rápido no macOS/iOS)
- Corrige `opacity: 0.7` inline → `var(--text-tertiary)` (acessibilidade)
- Borders ajustadas para `0.5px` (padrão Liquid Glass)
- Hover states e transições spring adicionados
- `valor-boxes` grid: `repeat(3, 1fr)` → `auto-fit` (suporta 3-4 colunas)
- Auth pages (login/cadastro): tipografia SF Pro com letter-spacing
- Onboarding: step-dots com glow, botões com hover states

## Testes
- 55 passando (50 existentes + 5 novos para família)
- Todas as páginas renderizam corretamente